### PR TITLE
Remove default value from text fields for mysql

### DIFF
--- a/app/models/scan.rb
+++ b/app/models/scan.rb
@@ -481,6 +481,10 @@ class Scan < ActiveRecord::Base
         end
     end
 
+    def error_messages
+      return @error_messages.nil? : "" ? @error_messages
+    end
+
     private
 
     def push_framework_issues( a_issues )

--- a/db/migrate/20121213171058_create_scans.rb
+++ b/db/migrate/20121213171058_create_scans.rb
@@ -16,7 +16,7 @@ class CreateScans < ActiveRecord::Migration
             t.string :status
             t.text :statistics
             t.text :issue_digests
-            t.text :error_messages, default: ''
+            t.text :error_messages
             t.integer :owner_id
             t.datetime :finished_at
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -191,7 +191,7 @@ ActiveRecord::Schema.define(version: 20130302162250) do
     t.string   "status"
     t.text     "statistics"
     t.text     "issue_digests"
-    t.text     "error_messages",                default: ""
+    t.text     "error_messages"
     t.integer  "owner_id"
     t.datetime "finished_at"
     t.integer  "root_id"


### PR DESCRIPTION
MySql doesn't support default values for text fields. This removes them,
and fixes the model to return an empty string when the field is NULL.
