### PR TITLE
Only load the js files that we need from bootstrap instead of everything...

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,7 +30,9 @@
 //= require jquery_ujs
 //= require jquery.turbolinks
 //= require turbolinks
-//= require bootstrap
+//= require bootstrap-tooltip
+//= require bootstrap-tab
+//= require bootstrap-dropdown
 //= require ./jqplot/jquery.jqplot.js
 //= require_tree .
 


### PR DESCRIPTION
I noticed that the web app is loading every javascript file from bootstrap, but I checked and it doesn't look like you are using carousel and some others, so I did some testing and these seem to be the only ones needed.
