### PR TITLE
Fix sharing modal and node leak

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,6 +30,7 @@
 //= require jquery_ujs
 //= require jquery.turbolinks
 //= require turbolinks
+//= require bootstrap-modal
 //= require bootstrap-tooltip
 //= require bootstrap-tab
 //= require bootstrap-dropdown
@@ -68,7 +69,7 @@ if( typeof String.prototype.endsWith != 'function' ) {
 }
 
 var tabCookieName        = 'activeTabGroup';
-var accordionCookieName = 'activeAccordionGroup';
+var accordionCookieName  = 'activeAccordionGroup';
 
 // Parent must have 'position: relative;'
 function scrollToChild( parent, child ){

--- a/app/views/shared/_share_form.html.erb
+++ b/app/views/shared/_share_form.html.erb
@@ -14,7 +14,7 @@
         </a>
     <% end %>
 
-    <div id="share<%= model.class %><%= model.id %>" class="modal hide fade"
+    <div id="share<%= model.class %><%= model.id %>" class="sharing-window modal hide fade"
          tabindex="-1" role="dialog">
 
         <div class="modal-header">
@@ -40,11 +40,21 @@
     </div>
 
     <script type="text/javascript">
+
         // If we have a scan table then we're probably inside it and since
         // the table will keep being updated by AJAX we must move the modal dialog
         // out of it otherwise it'll keep vanishing with each AJAX refresh.
-        $( '#share<%= model.class %><%= model.id %>' ).each( function() {
-            $( '#<%= model.class.to_s.downcase %>s' ).parent().before( this );
-        })
+
+        var shareModel    = '<%= model.class %>',
+            shareSelector = '.sharing-window';
+
+        if ( $(shareSelector).length < 3) {
+            $( shareSelector ).each( function() {
+                $( "#" + shareModel.toLowerCase() + "s" ).parent().before( this );
+            });
+        }
+
+        $(".nav.nav-list").find(shareSelector).remove();
+        
     </script>
 <% end %>


### PR DESCRIPTION
The Share option on the "actions" sidebar menu stopped working because it needed bootstrap-model which I added back.

But I also noticed on the chrome dev tools that the javascript to keep it from closing on an ajax refresh was also creating new copies of the modal dialog over and over without removing the old ones, creating a small leak, so I did a small hack to fix it since I'm not sure where this is coming from, (but a wild guess is that this has something to do with ajax being async and stuff happening in the incorrect order)

![share-leak](https://f.cloud.github.com/assets/1369748/1627997/42cde81a-5701-11e3-8a45-4fab701d46a8.png)
