### PR TITLE
Minor layout changes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,6 +30,8 @@
 //= require jquery_ujs
 //= require jquery.turbolinks
 //= require turbolinks
+//= require bootstrap-transition
+//= require bootstrap-collapse
 //= require bootstrap-modal
 //= require bootstrap-tooltip
 //= require bootstrap-tab

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -38,6 +38,10 @@
     width: 10000px;
 }
 
+.label {
+    padding: 4px 5px !important;
+}
+
 .content {
     //background-color: #eee;
     padding: 20px;

--- a/app/assets/stylesheets/scans.css.scss
+++ b/app/assets/stylesheets/scans.css.scss
@@ -18,7 +18,10 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
+
 #scans {
+    margin-top: 10px;
+
     label {
         display: inline;
     }
@@ -58,7 +61,7 @@
 
     #scan_description {
         width: 100%;
-        height: 100px;
+        height: 85px;
     }
 
     #scan_type {

--- a/app/views/scans/_editable_description.html.erb
+++ b/app/views/scans/_editable_description.html.erb
@@ -38,7 +38,7 @@
         </script>
     <% end %>
 
-    <a href="#" class="btn btn-inverse btn-mini" id="edit-description-btn">
+    <a href="#" class="btn btn-inverse btn-mini" id="edit-description-btn" style="display: none">
         Edit description
     </a>
 <% end %>

--- a/app/views/scans/_show_active.html.erb
+++ b/app/views/scans/_show_active.html.erb
@@ -135,7 +135,7 @@
 <script type="text/javascript">
     window.setupScanCallbacks();
 
-    $( '#edit-description-btn' ).show();
+    //$( '#edit-description-btn' ).show();
     $( '#issues' ).show();
     $( '#scan-sidebar' ).show( 'slow' );
     $( 'li#toggle-statistics' ).fadeIn( 'slow' );

--- a/app/views/scans/_show_inactive.html.erb
+++ b/app/views/scans/_show_inactive.html.erb
@@ -53,7 +53,7 @@
     <script type="text/javascript">
         window.setupScanCallbacks();
 
-        $( '#edit-description-btn' ).show();
+        //$( '#edit-description-btn' ).show();
         $( '#issues' ).show();
         $( '#scan-sidebar' ).show();
         $( 'li#toggle-statistics' ).fadeOut( 'slow' );


### PR DESCRIPTION
- Added a bit of margin on #scans so there is some space after the breadcrumb
- Made labels a little bit bigger with some extra padding
- The description button no longer flashes and dissapears
- Added collapse plugin from bootstrap so hidding and showing charts works again
- Made the description box a little bit smaller.
