### PR TITLE
Acquire bundled gems over SSL, ignore asset cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ db/*.sqlite3
 /doc/app/
 /doc/features.html
 /doc/specs.html
+/public/assets
 /public/cache
 /public/stylesheets/compiled
 /public/system/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 gem 'rails', '4.0.3'
 


### PR DESCRIPTION
Security tools not using secure protocols for dependencies
could be bad, use SSL to acquire gems, deter MITM.
Ignore the asset cache generated by rake assets:precompile.
