### PR TITLE
Changed yaml_string field to textarea

### DIFF
--- a/app/views/profiles/plugin_options/_option.html.erb
+++ b/app/views/profiles/plugin_options/_option.html.erb
@@ -4,9 +4,28 @@
         value:       value
 } %>
 
-<%= render partial: 'profiles/plugin_options/option_input', locals: {
-        plugin_name: plugin_name,
-        option:      option,
-        value:       value,
-        disabled:    disabled
+<% if plugin_name == 'vector_feed'%>
+        <%= option.name %>
+        <% if option.name.to_s == 'yaml_string' %>
+                <%= render partial: 'profiles/plugin_options/option_textarea', locals: {
+                        plugin_name: plugin_name,
+                        option:      option,
+                        value:       value,
+                        disabled:    disabled
 } %>
+        <% else %>
+                <%= render partial: 'profiles/plugin_options/option_input', locals: {
+                        plugin_name: plugin_name,
+                        option:      option,
+                        value:       value,
+                        disabled:    disabled
+                } %>
+        <% end %>
+<% else %>
+        <%= render partial: 'profiles/plugin_options/option_input', locals: {
+                plugin_name: plugin_name,
+                option:      option,
+                value:       value,
+                disabled:    disabled
+        } %>
+<% end %>

--- a/app/views/profiles/plugin_options/_option_textarea.html.erb
+++ b/app/views/profiles/plugin_options/_option_textarea.html.erb
@@ -1,0 +1,6 @@
+<% disabled   = false if local_assigns[:disabled].nil? %>
+
+<% required = option.required? ? 'required' : 'optional' %>
+
+<textarea id="profile_plugins_<%= plugin_name %>_<%= option.name %>"
+   name="profile[plugins][<%= plugin_name %>][<%= option.name %>]" <%= 'disabled' if disabled %> class="string <%= required %>"><%= value %></textarea>


### PR DESCRIPTION
When pasting the contents of a vector file in to the yaml_string field in the webui, it would strip our the new lines resulting in unusable yaml. The solution is to change this option field to a textarea which preserves the new lines.